### PR TITLE
Bugfix - Do not use Method Made for Testing

### DIFF
--- a/src/core/password.rs
+++ b/src/core/password.rs
@@ -19,9 +19,9 @@ pub struct Password {
 }
 
 impl Password {
-    pub fn new(password: String, salt_length: u16) -> Self {
+    pub fn new(password: &str, salt_length: u16) -> Self {
         let salt = make_salt(salt_length);
-        let hash = hash_password(&password, &salt);
+        let hash = hash_password(password, &salt);
         Self { hash, salt }
     }
 
@@ -51,7 +51,7 @@ mod tests {
 
     #[test]
     fn test_password() {
-        let password = "password".to_string();
+        let password = "password";
         let salt_length = 16;
         let password = Password::new(password, salt_length);
         assert!(password.verify("password"));

--- a/src/root_password.rs
+++ b/src/root_password.rs
@@ -1,27 +1,60 @@
 use crate::core::password::Password;
-use rpassword::prompt_password_from_bufread;
-use std::io::{stdin, stdout};
+use rpassword::prompt_password;
 use tokio::fs;
 
 static ROOT_PASSWORD_FILE: &str = "root_password.yaml";
+static INPUT_ROOT_PASSWORD: &str = "Input root password: ";
 
 pub async fn create_root_password() -> Result<(), String> {
-    let mut stdin = stdin().lock();
-    let mut stdout = stdout().lock();
-    let root_password = prompt_password_from_bufread(
-        &mut stdin,
-        &mut stdout,
-        "Input root \
-    password: ",
-    )
-    .map_err(|e| format!("Could not read password because of {:?}", e))?;
+    let root_password = prompt_password(INPUT_ROOT_PASSWORD)
+        .map_err(|e| format!("Could not read password because of {:?}", e))?;
 
+    save_root_password(&root_password).await?;
+
+    Ok(())
+}
+
+async fn save_root_password(password: &str) -> Result<(), String> {
+    println!("Hashing root password.");
+    let password = Password::new(password, 16);
+
+    println!("Writing root password to file.");
     fs::write(
         ROOT_PASSWORD_FILE,
-        serde_yaml::to_string(&Password::new(root_password, 16))
+        serde_yaml::to_string(&password)
             .map_err(|e| format!("Could not serialize password because of {:?}", e))?,
     )
     .await
     .map_err(|e| format!("Could not write password because of {:?}", e))?;
+
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    mod save_root_password {
+        use super::*;
+
+        #[tokio::test]
+        async fn saves_the_root_password_correctly() {
+            save_root_password("test")
+                .await
+                .expect("Could not save password.");
+
+            let file_text_content = fs::read_to_string(ROOT_PASSWORD_FILE)
+                .await
+                .expect("Could not read password.");
+
+            let password: Password =
+                serde_yaml::from_str(&file_text_content).expect("Could not deserialize password.");
+
+            assert!(password.verify("test"));
+
+            fs::remove_file(ROOT_PASSWORD_FILE)
+                .await
+                .expect("Could not remove file.");
+        }
+    }
 }

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -2,7 +2,6 @@ use assert_cmd::Command;
 use chrono::{TimeDelta, Utc};
 use lazy_static::lazy_static;
 use std::sync::Mutex;
-use tokio_test::assert_ok;
 
 const BIN: &str = "cloud_scraper";
 
@@ -62,20 +61,4 @@ fn run_env_debug_with_empty_config_cli_exit_override() {
         .stderr(predicates::str::contains("Starting engine"));
     let end = Utc::now();
     assert!(end - start < TimeDelta::try_seconds(1).unwrap());
-}
-
-#[test]
-fn run_root_password_subcommand() {
-    let _lock = MUTEX.lock().unwrap();
-    let mut cmd = Command::cargo_bin(BIN).expect("Failed to build command");
-    cmd.env("RUST_LOG", "debug")
-        .arg("root-password")
-        .write_stdin("password\n")
-        .assert()
-        .stdout(predicates::str::contains("Input root password:"))
-        .success();
-
-    assert_ok!(std::fs::metadata("root_password.yaml"));
-
-    std::fs::remove_file("root_password.yaml").expect("Failed to delete file");
 }


### PR DESCRIPTION
It reveals the sensitive text in the prompt. Delete the CLI end to end test exercising password entry & substituted with integration testing.