### PR TITLE
Add a Root Email Config Property

### DIFF
--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -16,6 +16,7 @@ const DEFAULT_SITE_FOLDER: &str = ".site";
 #[derive(Debug, Deserialize)]
 pub(crate) struct Config {
     domain_config: Option<crate::domain::config::DomainConfig>,
+    email: Option<String>,
     exit_after: Option<u64>,
     sinks: HashMap<String, Value>,
     sources: HashMap<String, Value>,
@@ -38,6 +39,7 @@ impl Config {
             }
             None => Self {
                 domain_config: None,
+                email: None,
                 exit_after: serve_args.exit_after,
                 sinks: Self::sinks(),
                 sources: Self::sources(),
@@ -52,6 +54,7 @@ impl Config {
     pub(crate) fn new_test() -> Arc<Self> {
         Arc::new(Self {
             domain_config: None,
+            email: None,
             exit_after: None,
             sinks: Self::sinks(),
             sources: Self::sources(),
@@ -93,6 +96,10 @@ impl Config {
 impl DomainConfig for Config {
     fn domain_config(&self) -> Option<&crate::domain::config::DomainConfig> {
         self.domain_config.as_ref()
+    }
+
+    fn email(&self) -> Option<&str> {
+        self.email.as_deref()
     }
 
     fn exit_after(&self) -> Option<Duration> {
@@ -150,6 +157,7 @@ mod tests {
     fn test_instantiate() {
         let config = Config {
             domain_config: None,
+            email: None,
             exit_after: None,
             sinks: Default::default(),
             sources: Default::default(),

--- a/src/core/engine.rs
+++ b/src/core/engine.rs
@@ -281,6 +281,10 @@ pub(crate) mod tests {
             None
         }
 
+        fn email(&self) -> Option<&str> {
+            None
+        }
+
         fn exit_after(&self) -> Option<Duration> {
             Some(Duration::from_millis(10))
         }

--- a/src/domain/config.rs
+++ b/src/domain/config.rs
@@ -12,6 +12,7 @@ pub(crate) trait Config: Send + Sync {
     fn domain_is_defined(&self) -> bool {
         self.domain_config().is_some()
     }
+    fn email(&self) -> Option<&str>;
     fn exit_after(&self) -> Option<Duration> {
         None
     }
@@ -30,6 +31,13 @@ pub(crate) trait Config: Send + Sync {
 
     fn sanity_check(&self) -> Result<(), String> {
         let mut errors = vec![];
+
+        if self.domain_is_defined() {
+            if self.email().is_none() {
+                errors.push("No email configured".to_string());
+            }
+        }
+
         for pipeline in self.pipelines() {
             if !self.sink_configured(&pipeline.sink) {
                 errors.push(format!("Sink '{}' not configured", pipeline.sink));
@@ -56,7 +64,7 @@ pub(crate) trait Config: Send + Sync {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 pub struct DomainConfig {
     pub builder_contacts: Vec<String>,
     pub domain_name: String,
@@ -203,9 +211,24 @@ pub(crate) mod tests {
             translator: None,
         }));
         assert!(bad_config.sanity_check().is_err());
+
+        let domain_config = Some(DomainConfig {
+            builder_contacts: vec!["builder@contact.com".to_string()],
+            domain_name: "the.domain".to_string(),
+            poll_attempts: 0,
+            poll_interval_seconds: 0,
+        });
+
+        let bad_config = TestConfig::new_domain_email(domain_config.clone(), None);
+        assert!(bad_config.sanity_check().is_err());
+
+        let config = TestConfig::new_domain_email(domain_config, Some("the@email.com".to_string()));
+        assert!(config.sanity_check().is_ok());
     }
 
     pub(crate) struct TestConfig {
+        domain_config: Option<DomainConfig>,
+        email: Option<String>,
         value: Value,
         pipelines: Vec<PipelineConfig>,
     }
@@ -213,6 +236,8 @@ pub(crate) mod tests {
     impl TestConfig {
         pub(crate) fn new(pipeline_config: Option<PipelineConfig>) -> Self {
             Self {
+                domain_config: None,
+                email: None,
                 pipelines: vec![if let Some(pipeline_config) = pipeline_config {
                     pipeline_config
                 } else {
@@ -225,11 +250,27 @@ pub(crate) mod tests {
                 value: Value::Mapping(Mapping::new()),
             }
         }
+
+        pub fn new_domain_email(
+            domain_config: Option<DomainConfig>,
+            email: Option<String>,
+        ) -> Self {
+            Self {
+                domain_config,
+                email,
+                pipelines: vec![PipelineConfig::new("test", "test", None)],
+                value: Value::Mapping(Mapping::new()),
+            }
+        }
     }
 
     impl Config for TestConfig {
         fn domain_config(&self) -> Option<&DomainConfig> {
-            None
+            self.domain_config.as_ref()
+        }
+
+        fn email(&self) -> Option<&str> {
+            self.email.as_deref()
         }
 
         fn sink(&self, sink_identifier: &str) -> Option<&Value> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,10 @@ mod tests {
             None
         }
 
+        fn email(&self) -> Option<&str> {
+            None
+        }
+
         fn sink(&self, _sink_identifier: &str) -> Option<&Value> {
             None
         }


### PR DESCRIPTION
To identify one domain owner address. This is needed in Google's Oauth2 client data.

Make it compulsory if a domain is defined.